### PR TITLE
Fix/model sprout hooks

### DIFF
--- a/src/PdbModelInterface.php
+++ b/src/PdbModelInterface.php
@@ -38,6 +38,17 @@ interface PdbModelInterface
 
 
     /**
+     * Data to be inserted or updated.
+     *
+     * This is a perfect spot to add generated values like audit rows
+     * (date_added, date_modified, uid, etc).
+     *
+     * @return array [ column => value ]
+     */
+    public function getSaveData(): array;
+
+
+    /**
      * Save this model.
      *
      * @return bool

--- a/src/PdbModelTrait.php
+++ b/src/PdbModelTrait.php
@@ -215,7 +215,6 @@ trait PdbModelTrait
     public function save(): bool
     {
         $pdb = static::getConnection();
-        $table = static::getTableName();
 
         $transact = false;
 
@@ -235,13 +234,11 @@ trait PdbModelTrait
 
             $data = $this->getSaveData();
 
-            if ($this->id > 0) {
-                if (empty($data)) return true;
-                $pdb->update($table, $data, [ 'id' => $this->id ]);
+            if (empty($data)) {
+                return true;
             }
-            else {
-                $data['id'] = $pdb->insert($table, $data);
-            }
+
+            $this->_internalSave($data);
 
             // Punch it.
             if ($transact and $pdb->inTransaction()) {
@@ -271,6 +268,30 @@ trait PdbModelTrait
      */
     protected function _beforeSave()
     {
+    }
+
+
+    /**
+     * Perform inserts and updates.
+     *
+     * This is wrapped by the save() method with a transaction.
+     *
+     * This modifies the 'ID' into the `$data` array to the
+     *
+     * @param array $data as created by {@see getSaveData()}, this is mutable
+     * @return void
+     */
+    protected function _internalSave(array &$data)
+    {
+        $pdb = static::getConnection();
+        $table = static::getTableName();
+
+        if ($this->id > 0) {
+            $pdb->update($table, $data, [ 'id' => $this->id ]);
+        }
+        else {
+            $data['id'] = $pdb->insert($table, $data);
+        }
     }
 
 

--- a/src/PdbModelTrait.php
+++ b/src/PdbModelTrait.php
@@ -227,11 +227,6 @@ trait PdbModelTrait
         try {
             $this->_beforeSave();
 
-            // Only populate defaults for new models.
-            if (!$this->id) {
-                $this->populateDefaults();
-            }
-
             $data = $this->getSaveData();
 
             if (empty($data)) {
@@ -243,10 +238,6 @@ trait PdbModelTrait
             // Punch it.
             if ($transact and $pdb->inTransaction()) {
                 $pdb->commit();
-            }
-
-            if (isset($data['id'])) {
-                $this->id = $data['id'];
             }
 
             $this->_afterSave($data);
@@ -268,6 +259,10 @@ trait PdbModelTrait
      */
     protected function _beforeSave()
     {
+        // Only populate defaults for new models.
+        if (!$this->id) {
+            $this->populateDefaults();
+        }
     }
 
 
@@ -303,6 +298,9 @@ trait PdbModelTrait
      */
     protected function _afterSave(array $data)
     {
+        if (isset($data['id'])) {
+            $this->id = $data['id'];
+        }
     }
 
 

--- a/tests/Models/Model.php
+++ b/tests/Models/Model.php
@@ -2,12 +2,8 @@
 
 namespace kbtests\Models;
 
-use karmabunny\kb\Collection;
 use karmabunny\kb\Uuid;
-use kbtests\Database;
 use karmabunny\pdb\Pdb;
-use karmabunny\pdb\PdbModelInterface;
-use karmabunny\pdb\PdbModelTrait;
 
 /**
  * A base model.
@@ -17,12 +13,8 @@ use karmabunny\pdb\PdbModelTrait;
  *
  * This is a good chance to combine in Collections and other helpers.
  */
-abstract class Model extends Collection implements PdbModelInterface
+abstract class Model extends Record
 {
-    use PdbModelTrait {
-        getSaveData as private _getSaveData;
-    }
-
     /** @var string */
     public $uid;
 
@@ -36,16 +28,9 @@ abstract class Model extends Collection implements PdbModelInterface
     public $active = true;
 
 
-    /** @inheritdoc */
-    public static function getConnection(): Pdb
-    {
-        return Database::getConnection();
-    }
-
-
     public function getSaveData(): array
     {
-        $data = $this->_getSaveData();
+        $data = parent::getSaveData();
         $now = Pdb::now();
 
         if (!$this->id) {
@@ -63,6 +48,8 @@ abstract class Model extends Collection implements PdbModelInterface
 
     protected function _afterSave(array $data)
     {
+        parent::_afterSave($data);
+
         if (isset($data['date_added'])) {
             $this->date_added = $data['date_added'];
         }

--- a/tests/Models/Record.php
+++ b/tests/Models/Record.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace kbtests\Models;
+
+use karmabunny\kb\Collection;
+use kbtests\Database;
+use karmabunny\pdb\Pdb;
+use karmabunny\pdb\PdbModelInterface;
+use karmabunny\pdb\PdbModelTrait;
+
+/**
+ * A base model.
+ *
+ * Using this library will typically require the user to create something
+ * like this.
+ *
+ * This is a good chance to combine in Collections and other helpers.
+ */
+abstract class Record extends Collection implements PdbModelInterface
+{
+    use PdbModelTrait;
+
+    /** @inheritdoc */
+    public static function getConnection(): Pdb
+    {
+        return Database::getConnection();
+    }
+}

--- a/tests/Models/SproutItem.php
+++ b/tests/Models/SproutItem.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace kbtests\Models;
+
+
+/**
+ * A sprout model for testing 'internalSave' overrides.
+ */
+class SproutItem extends SproutModel
+{
+
+    /** @inheritdoc */
+    public static function getTableName(): string
+    {
+        return 'sprout';
+    }
+
+
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $uid;
+
+    /** @var string */
+    public $date_added;
+}

--- a/tests/Models/SproutModel.php
+++ b/tests/Models/SproutModel.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace kbtests\Models;
+
+use karmabunny\pdb\Pdb;
+
+/**
+ * Base models from Sprout.
+ *
+ * It's not entirely important that this is 1-to-1 with Sprout - we're simply
+ * testing the 'internalSave' mechanism.
+ */
+abstract class SproutModel extends Record
+{
+
+    /** @inheritdoc */
+    public function getSaveData(): array
+    {
+        $data = parent::getSaveData();
+
+        $pdb = static::getConnection();
+        $table = static::getTableName();
+        $now = Pdb::now();
+
+        // Include the uuid if it's not already set.
+        // This may return NIL, that's OK - we do an insert + update later.
+        if (empty($data['uid']) and property_exists($this, 'uid')) {
+            $data['uid'] = $pdb->generateUid($table, (int) $this->id);
+        }
+
+        if (property_exists($this, 'date_modified')) {
+            $data['date_modified'] = $now;
+        }
+
+        if (!$this->id) {
+            if (property_exists($this, 'date_added')) {
+                $data['date_added'] = $now;
+            }
+        }
+
+        return $data;
+    }
+
+
+    /** @inheritdoc */
+    protected function _internalSave(array &$data)
+    {
+        $pdb = static::getConnection();
+        $table = static::getTableName();
+
+        if ($this->id > 0) {
+            $pdb->update($table, $data, [ 'id' => $this->id ]);
+        }
+        else {
+            $data['id'] = $pdb->insert($table, $data);
+
+            // Now generate a real uuid.
+            if (property_exists($this, 'uid')) {
+                $data['uid'] = $pdb->generateUid($table, $data['id']);
+
+                $pdb->update(
+                    $table,
+                    [ 'uid' => $data['uid'] ],
+                    [ 'id' => $data['id'] ]
+                );
+            }
+        }
+    }
+
+
+    /** @inheritdoc */
+    protected function _afterSave(array $data)
+    {
+        parent::_afterSave($data);
+
+        if (
+            property_exists($this, 'date_modified')
+            and isset($data['date_modified'])
+        ) {
+            $this->date_modified = $data['date_modified'];
+        }
+
+        if (
+            property_exists($this, 'date_added')
+            and isset($data['date_added'])
+        ) {
+            $this->date_added = $data['date_added'];
+        }
+
+        if (
+            property_exists($this, 'uid')
+            and isset($data['uid'])
+        ) {
+            $this->uid = $data['uid'];
+        }
+    }
+
+}

--- a/tests/db_struct.xml
+++ b/tests/db_struct.xml
@@ -28,6 +28,17 @@
         </index>
     </table>
 
+    <table name="sprout">
+        <column name="id" type="INT UNSIGNED" allownull="0" autoinc="1"/>
+        <column name="date_added" type="DATETIME" allownull="0"/>
+        <column name="uid" type="CHAR(36)" allownull="0"/>
+
+        <column name="name" type="TEXT" allownull="0"/>
+
+        <primary>
+            <col name="id"/>
+        </primary>
+    </table>
 
     <table name="logs">
         <column name="id" type="INT UNSIGNED" allownull="0" autoinc="1"/>


### PR DESCRIPTION
OK so primarily this moves the insert/update component into an `_internalSave()` - giving Sprout (or others) an opportunity to override and extend functionality.

I've also moved some bits into before/after hooks also. So extending models can disable, customise or inherit this functionality as it pleases.

You can see in the sample 'SproutModel' test how Sprout uses this to create the UUIDv5 process. This test is actually replicated into Sprout upstream so we're testing against the real model classes too. Sprout will also have the lightweight 'Record' type also. So once you're approved this I'll merge and publish Sprout also.