### PR TITLE
Feat/polyfill condition tables

### DIFF
--- a/src/Models/PdbCondition.php
+++ b/src/Models/PdbCondition.php
@@ -224,6 +224,36 @@ class PdbCondition
 
 
     /**
+     * Walk through all nested conditions.
+     *
+     * Each callback is able to modify the condition in-place.
+     *
+     * @param PdbCondition|PdbCondition[] $condition
+     * @param callable $fn (PdbCondition &$condition) => void
+     * @return void
+     */
+    public static function walk(&$condition, $fn)
+    {
+        if ($condition instanceof static) {
+            $fn($condition);
+
+            if ($condition->value instanceof static) {
+                $fn($condition->value);
+            }
+            else if (is_array($condition->value)) {
+                self::walk($condition->value, $fn);
+            }
+        }
+        else if (is_array($condition)) {
+            foreach ($condition as &$item) {
+                self::walk($item, $fn);
+            }
+            unset($item);
+        }
+    }
+
+
+    /**
      * Validate this condition.
      *
      * @return void

--- a/src/PdbQuery.php
+++ b/src/PdbQuery.php
@@ -713,6 +713,11 @@ class PdbQuery implements Arrayable, JsonSerializable
             $fields = [];
             foreach ($this->_group as $field) {
                 if (!preg_match(PdbHelpers::RE_FUNCTION, $field)) {
+                    // Apply the table if missing.
+                    if ($from and strpos($field, '.') === false) {
+                        $field = "{$from}.{$field}";
+                    }
+
                     $field = $this->pdb->quoteField($field);
                 }
 
@@ -748,6 +753,11 @@ class PdbQuery implements Arrayable, JsonSerializable
             $fields = [];
             foreach ($this->_order as $field => $order) {
                 if (!preg_match(PdbHelpers::RE_FUNCTION, $field)) {
+                    // Apply the table if missing.
+                    if ($from and strpos($field, '.') === false) {
+                        $field = "{$from}.{$field}";
+                    }
+
                     $field = $this->pdb->quoteField($field);
                 }
 


### PR DESCRIPTION
This adds a query modifier for any fields that don't already have a `table.column` form.

It takes the table name, or alias, from the `from()` modifier and simply tacks it onto any fields that are I guess 'naked'.

This applies to:
- select() fields
- where() conditions
- join() conditions
- having() conditions
- orderBy()
- groupBy()

## Example

```php
$query = $pdb->find('users AS user')
  ->fixTables()
  ->select('name', 'other.field')
  ->innerJoin('others AS other', ['other.user_id = user.id'])
  ->where(['OR' => [
     'other.status' => 'deleted', 
     'date_deleted' => null,
  ]])
  ->orderBy('record_order');
```

produces:

```sql
SELECT user.name, other.field
FROM users AS user
INNER JOIN others AS other
  ON other.user_id = user.id
WHERE other.status = 'deleted'
  OR user.date_deleted IS NULL
ORDER BY user.record_order
```


## Regarding conditions

It only performs this modification on the left-hand side of an expression. If the right-hand is missing the table then there's not much we can do. Or is there?

I'm not sure about string conditions either. They're quite an weird edge-case altogether. 

Some testing will clarify all of this.

## Draft because:

- fixTables() is a terrible name
- no tests!
- orderBy()/groupBy() should check against the select() aliases to prevent accidentally prefixing an alias