### PR TITLE
Feat/utf8 aliases

### DIFF
--- a/guides/config.md
+++ b/guides/config.md
@@ -55,7 +55,13 @@ Finally, the object is simply validated as an appropriate subclass and passed th
 
 ### MySQL Character sets
 
-Character sets for MySQL are a tortured story. Since at least 2002 the default has been 'utf8' which is an alias for 'utf8mb3' - this uses up to 3 bytes per character. Fortunately, MySQL has since supported 'utf8mb4' since version v5.7 and the default 'utf8' has been re-aliased to 'utf8mb4' since v8.0 and MariaDB v10.5.
+Character sets for MySQL are a tortured story. Since at least 2002 the default has been 'utf8' for which 'utf8mb3' is an alias - this uses up to 3 bytes per character. Fortunately, MySQL has since supported 'utf8mb4' since version v5.7 (MariaDB 10.2).
+
+Since MariaDB 10.6 has swapped the alias (utf8 -> utf8mb3) however this is _configurable_ and will eventually be a permanent change to alias as 'utf8mb4'.
+
+https://mariadb.com/docs/server/release-notes/mariadb-enterprise-server-10-6/10-6-4-1/#Operational_Enhancements
+
+It's recommended to avoid aliases and shorthands altogether. Use the full names (i.e. utf8mb3 or utf8mb4).
 
 
 ### Hacks

--- a/src/Drivers/PdbMysql.php
+++ b/src/Drivers/PdbMysql.php
@@ -333,13 +333,16 @@ class PdbMysql extends Pdb
     public function getTableAttributes(string $table)
     {
         $q = "SELECT
-                CREATE_TIME,
-                UPDATE_TIME,
-                ENGINE,
-                TABLE_COLLATION,
-                TABLE_COMMENT,
-                AUTO_INCREMENT
-            FROM INFORMATION_SCHEMA.TABLES
+                T.CREATE_TIME,
+                T.UPDATE_TIME,
+                T.ENGINE,
+                T.TABLE_COLLATION,
+                T.TABLE_COMMENT,
+                T.AUTO_INCREMENT,
+                C.CHARACTER_SET_NAME
+            FROM INFORMATION_SCHEMA.TABLES AS T
+            INNER JOIN INFORMATION_SCHEMA.COLLATION_CHARACTER_SET_APPLICABILITY AS C
+                ON T.TABLE_COLLATION = C.COLLATION_NAME
             WHERE TABLE_SCHEMA = ?
             AND TABLE_NAME = ?
         ";

--- a/src/PdbConfig.php
+++ b/src/PdbConfig.php
@@ -135,6 +135,13 @@ class PdbConfig extends Collection
     public $character_set = 'utf8';
 
     /**
+     * Default collation, default utf8.
+     *
+     * @var string
+     */
+    public $collation = 'utf8_unicode_ci';
+
+    /**
      * Connection timeout.
      *
      * @var int

--- a/src/PdbSync.php
+++ b/src/PdbSync.php
@@ -488,6 +488,17 @@ class PdbSync
             $engine = $table->attributes['engine'];
             $collate = $table->attributes['collate'];
 
+            $old_mode = $this->pdb->query('SELECT @@old_mode', [], 'val?');
+            if ($old_mode == 'UTF8_IS_UTF8MB3') {
+                if ($charset == 'utf8') {
+                    $charset = 'utf8mb3';
+                }
+
+                if (strpos($collate, 'utf8_') === 0) {
+                    $collate = 'utf8mb3' . substr($collate, 4);
+                }
+            }
+
             $bad_engine = false;
             if ($attributes['engine'] != $engine) {
                 $bad_engine = true;

--- a/src/PdbSync.php
+++ b/src/PdbSync.php
@@ -223,8 +223,7 @@ class PdbSync
 
             // TODO Super naive. Total hack. Do better.
             if (!isset($table->attributes['collate'])) {
-                $collation = $table->attributes['charset'] . '_general_ci';
-                $table->attributes['collate'] = $collation;
+                $table->attributes['collate'] = $this->pdb->config->collation;
             }
 
             if ($do['create']) {


### PR DESCRIPTION
Kind of tricky to test. If you fire up a mariadb 10.11 and import an old database it'll show up in a DB sync.

Overall I think it's relatively harmless, especially reading the `@@old_mode` means we don't have to think too hard.