### PR TITLE
Feat/condition interface

### DIFF
--- a/src/DataBinders/MathBinder.php
+++ b/src/DataBinders/MathBinder.php
@@ -60,7 +60,7 @@ class MathBinder implements PdbDataBinderInterface
      *
      * @param int|float $value
      * @param string $operator one of `self::OPERATORS`
-     * @param bool $invoice swap the operation: `{value} X {column}`
+     * @param bool $inverse swap the operation: `{value} X {column}`
      */
     public function __construct($value, string $operator, bool $inverse)
     {

--- a/src/Exceptions/InvalidConditionException.php
+++ b/src/Exceptions/InvalidConditionException.php
@@ -7,14 +7,14 @@
 namespace karmabunny\pdb\Exceptions;
 
 use InvalidArgumentException;
-use karmabunny\pdb\Models\PdbCondition;
+use karmabunny\pdb\Models\PdbConditionInterface;
 
 /**
  *
  */
 class InvalidConditionException extends InvalidArgumentException
 {
-    /** @var PdbCondition|null */
+    /** @var PdbConditionInterface|null */
     public $condition = null;
 
     /** @var string|null */
@@ -23,10 +23,10 @@ class InvalidConditionException extends InvalidArgumentException
 
     /**
      *
-     * @param PdbCondition $condition
+     * @param PdbConditionInterface $condition
      * @return static
      */
-    public function withCondition(PdbCondition $condition)
+    public function withCondition(PdbConditionInterface $condition)
     {
         $this->condition = $condition;
 

--- a/src/Exceptions/InvalidConditionException.php
+++ b/src/Exceptions/InvalidConditionException.php
@@ -30,8 +30,9 @@ class InvalidConditionException extends InvalidArgumentException
     {
         $this->condition = $condition;
 
-        $preview = $this->condition->getPreviewSql() ?: '???';
-        $this->message .= " \"{$preview}\"";
+        if ($preview = $this->condition->getPreviewSql()) {
+            $this->message .= " \"{$preview}\"";
+        }
 
         return $this;
     }

--- a/src/Models/PdbCompoundCondition.php
+++ b/src/Models/PdbCompoundCondition.php
@@ -16,8 +16,14 @@ use karmabunny\pdb\Pdb;
 class PdbCompoundCondition implements PdbConditionInterface
 {
 
-    const COMPOUNDS = [
+    const OPERATORS = [
         'NOT',
+        'OR',
+        'AND',
+        'XOR',
+    ];
+
+    const COMPOUNDS = [
         'OR',
         'AND',
         'XOR',
@@ -47,7 +53,7 @@ class PdbCompoundCondition implements PdbConditionInterface
     /** @inheritdoc */
     public function validate()
     {
-        if (!in_array($this->compound, self::COMPOUNDS)) {
+        if (!in_array($this->compound, self::OPERATORS)) {
             $message = "Unknown compound operator: '{$this->compound}'";
             throw (new InvalidConditionException($message))
                 ->withCondition($this);

--- a/src/Models/PdbCompoundCondition.php
+++ b/src/Models/PdbCompoundCondition.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2021 Karmabunny
+ */
+
+namespace karmabunny\pdb\Models;
+
+use karmabunny\pdb\Exceptions\InvalidConditionException;
+use karmabunny\pdb\Pdb;
+
+/**
+ *
+ * @package karmabunny\pdb
+ */
+class PdbCompoundCondition implements PdbConditionInterface
+{
+
+    const COMPOUNDS = [
+        'NOT',
+        'OR',
+        'AND',
+        'XOR',
+    ];
+
+    /** @var string */
+    public $compound;
+
+    /** @var PdbConditionInterface[] */
+    public $conditions = [];
+
+
+    /**
+     * Create a condition.
+     *
+     * @param string $compound
+     * @param PdbConditionInterface[] $conditions
+     */
+    public function __construct(string $compound, array $conditions)
+    {
+        $this->compound = trim(strtoupper($compound));
+        $this->compound = $compound;
+        $this->conditions = $conditions;
+    }
+
+
+    /** @inheritdoc */
+    public function validate()
+    {
+        if (!in_array($this->compound, self::COMPOUNDS)) {
+            $message = "Unknown compound operator: '{$this->compound}'";
+            throw (new InvalidConditionException($message))
+                ->withCondition($this);
+        }
+
+        foreach ($this->conditions as $condition) {
+            if (!$condition instanceof PdbConditionInterface) {
+                throw (new InvalidConditionException('Invalid condition'))
+                    ->withCondition($this)
+                    ->withActual($condition);
+            }
+
+            $condition->validate();
+        }
+    }
+
+
+    /** @inheritdoc */
+    public function build(Pdb $pdb, array &$values): string
+    {
+        // Special 'not' operator will perform a nested 'and'.
+        if ($this->compound === 'NOT') {
+            $compound = 'AND';
+            $sql = 'NOT ';
+        }
+        else {
+            $compound = $this->compound;
+            $sql = '';
+        }
+
+        $sql .= '(';
+        $first = true;
+
+        foreach ($this->conditions as $condition) {
+            if (!$first) {
+                $sql .= " {$compound} ";
+            }
+
+            $sql .= $condition->build($pdb, $values);
+            $first = false;
+        }
+
+        $sql .= ')';
+        return $sql;
+    }
+
+
+    /** @inheritdoc */
+    public function getPreviewSql(): string
+    {
+        if ($this->compound === 'NOT') {
+            $compound = 'AND';
+            $sql = 'NOT ';
+        }
+        else {
+            $compound = $this->compound;
+            $sql = '';
+        }
+
+
+        $sql .= '(';
+        $first = true;
+
+        foreach ($this->conditions as $condition) {
+            if (!$first) {
+                $sql .= " {$compound} ";
+            }
+
+            $sql .= ' ';
+            $sql .= $condition->getPreviewSql() ?: '(!!)';
+            $first = false;
+        }
+
+        $sql .= ')';
+        return $sql;
+    }
+
+
+    /** @inheritdoc */
+    public function __toString()
+    {
+        $preview = $this->getPreviewSql();
+        return $preview;
+    }
+}

--- a/src/Models/PdbCondition.php
+++ b/src/Models/PdbCondition.php
@@ -103,7 +103,7 @@ abstract class PdbCondition implements PdbConditionInterface
         // declare their intent. Exception can happen further up the call chain.
         //  e.g. in PdbQuery::join().
         if (is_numeric($key) and is_string($item)) {
-            throw new InvalidConditionException('Cannot implicitly parse unsafe conditions, please use PdbRawCondition');
+            throw new InvalidConditionException('Invalid string condition');
         }
 
         // Key-style conditions + nested conditions.

--- a/src/Models/PdbCondition.php
+++ b/src/Models/PdbCondition.php
@@ -30,7 +30,7 @@ abstract class PdbCondition implements PdbConditionInterface
      *
      * The third is only for equality, IN, IS NULL conditions.
      *
-     * @param string|int $key
+     * @param string|int|null $key
      * @param PdbConditionInterface|array|string|int|float|null $item
      * @return PdbConditionInterface
      * @throws InvalidConditionException
@@ -44,7 +44,10 @@ abstract class PdbCondition implements PdbConditionInterface
         }
 
         // Value-style conditions.
-        if (is_numeric($key) and is_array($item)) {
+        if (
+            ($key === null or is_numeric($key))
+            and is_array($item)
+        ) {
             $count = count($item);
 
             // key-style conditions + nested conditions.

--- a/src/Models/PdbCondition.php
+++ b/src/Models/PdbCondition.php
@@ -8,104 +8,17 @@ namespace karmabunny\pdb\Models;
 
 use InvalidArgumentException;
 use karmabunny\pdb\Exceptions\InvalidConditionException;
-use karmabunny\pdb\Pdb;
-use karmabunny\pdb\PdbHelpers;
-use PDOException;
 
 /**
+ * This is a helper for building conditions from the array syntax.
+ *
+ * Although you _can_ extend this to implement new conditions, best not.
+ * Use {@see PdbConditionInterface} instead.
  *
  * @package karmabunny\pdb
  */
-class PdbCondition implements PdbConditionInterface
+abstract class PdbCondition implements PdbConditionInterface
 {
-
-    const EQUAL = '=';
-    const LESS_THAN_EQUAL = '<=';
-    const GREATER_THAN_EQUAL = '>=';
-    const LESS_THAN = '<';
-    const GREATER_THAN = '>';
-    const NOT_EQUAL = '!=';
-    const NOT_EQUAL_ALT = '<>';
-    const IS = 'IS';
-    const IS_NOT = 'IS NOT';
-    const BETWEEN = 'BETWEEN';
-    const IN = 'IN';
-    const NOT_IN = 'NOT IN';
-    const CONTAINS = 'CONTAINS';
-    const BEGINS = 'BEGINS';
-    const ENDS = 'ENDS';
-    const IN_SET = 'IN SET';
-
-    const COMPOUNDS = [
-        'NOT',
-        'OR',
-        'AND',
-        'XOR',
-    ];
-
-    const OPERATORS = [
-        self::EQUAL,
-        self::LESS_THAN_EQUAL,
-        self::GREATER_THAN_EQUAL,
-        self::LESS_THAN,
-        self::GREATER_THAN,
-        self::NOT_EQUAL,
-        self::NOT_EQUAL_ALT,
-        self::IS,
-        self::IS_NOT,
-        self::BETWEEN,
-        self::IN,
-        self::NOT_IN,
-        self::CONTAINS,
-        self::BEGINS,
-        self::ENDS,
-        self::IN_SET,
-    ];
-
-
-    /** @var string|null */
-    public $operator;
-
-    /** @var string|null */
-    public $column;
-
-    /** @var mixed */
-    public $value;
-
-    /**
-     * This controls the bind method of the 'value'.
-     *
-     * - Given `null` this uses parametric binding. This is the safest method.
-     *
-     * - Use the `FIELD` type to treat the 'value' as a column/table type.
-     * This will apply the appropriate quoting method.
-     *
-     * - The `VALUE` type will use the PDO driver's 'quote()' method.
-     * However this is still not as safe as using natural bindings.
-     *
-     * @var string|null Pdb::QUOTE_FIELD|QUOTE_VALUE|null
-     **/
-    public $bind_type;
-
-    /**
-     * Create a condition.
-     *
-     * @param string|null $operator
-     * @param string|null $column
-     * @param mixed $value
-     */
-    public function __construct($operator, $column, $value, string $bind = null)
-    {
-        if ($operator) {
-            $operator = trim(strtoupper($operator));
-        }
-
-        $this->operator = $operator;
-        $this->column = $column;
-        $this->value = $value;
-        $this->bind_type = $bind;
-    }
-
 
     /**
      * Create a condition object from a shorthand array.
@@ -160,18 +73,17 @@ class PdbCondition implements PdbConditionInterface
                 // Shortcut for those not wrapping their conditions.
                 if ($operator === 'NOT' and is_string($column)) {
                     $condition = self::fromShorthand($column, $value);
-                    return new PdbCondition('NOT', null, [$condition]);
+                    return new PdbCompoundCondition('NOT', [$condition]);
                 }
 
-                return new PdbCondition($operator, $column, $value);
+                return new PdbSimpleCondition($operator, $column, $value);
             }
 
             // Value-style condition.
             // :: [FIELD, OPERATOR, VALUE]
             if ($count == 3) {
                 [$column, $operator, $value] = $item;
-
-                return new PdbCondition($operator, $column, $value);
+                return new PdbSimpleCondition($operator, $column, $value);
             }
 
             throw new InvalidArgumentException('Conditions must have 1, 2 or 3 items, not: ' . $count);
@@ -183,7 +95,7 @@ class PdbCondition implements PdbConditionInterface
         // - NOT to be used for unescaped values. Stick to array or key style.
         // - Doesn't support non-scalar values.
         if (is_numeric($key) and is_string($item)) {
-            return new PdbCondition(null, null, $item);
+            return new PdbRawCondition($item);
         }
 
         // Key-style conditions + nested conditions.
@@ -194,22 +106,22 @@ class PdbCondition implements PdbConditionInterface
 
             if (is_array($item)) {
                 // Support for nested conditions.
-                if (in_array($modifier, self::COMPOUNDS)) {
+                if (in_array($modifier, PdbCompoundCondition::COMPOUNDS)) {
                     $conditions = self::fromArray($item);
-                    return new PdbCondition($modifier, null, $conditions);
+                    return new PdbCompoundCondition($modifier, $conditions);
                 }
                 else {
-                    return new PdbCondition(self::IN, $key, $item);
+                    return new PdbSimpleCondition(PdbSimpleCondition::IN, $key, $item);
                 }
             }
             // Regular key-style conditions.
             else {
-                $operator = PdbCondition::EQUAL;
+                $operator = PdbSimpleCondition::EQUAL;
                 if ($item === null) {
-                    $operator = PdbCondition::IS;
+                    $operator = PdbSimpleCondition::IS;
                 }
 
-                return new PdbCondition($operator, $key, $item);
+                return new PdbSimpleCondition($operator, $key, $item);
             }
         }
 
@@ -237,406 +149,4 @@ class PdbCondition implements PdbConditionInterface
         return $conditions;
     }
 
-
-    /**
-     * Validate this condition.
-     *
-     * @return void
-     * @throws InvalidConditionException
-     * @throws InvalidArgumentException
-     */
-    public function validate()
-    {
-        // String conditions have little-to-no validation.
-        if ($this->operator === null) {
-            return;
-        }
-
-        if (!is_scalar($this->operator)) {
-            $message = 'Invalid operator: ' . gettype($this->operator);
-                throw (new InvalidConditionException($message))
-                    ->withCondition($this);
-        }
-
-        if ($this->column !== null) {
-            if (!in_array($this->operator, self::OPERATORS)) {
-                $message = "Unknown operator: '{$this->operator}'";
-                throw (new InvalidConditionException($message))
-                    ->withCondition($this);
-            }
-        }
-        else {
-            if (!in_array($this->operator, self::COMPOUNDS)) {
-                $message = "Unknown compound operator: '{$this->operator}'";
-                throw (new InvalidConditionException($message))
-                    ->withCondition($this);
-            }
-        }
-
-        // Skip the rest for a nested condition.
-        if ($this->column === null) {
-            return;
-        }
-
-        if (!is_scalar($this->column)) {
-            $message = 'Column name must be scalar';
-            throw (new InvalidConditionException($message))
-                ->withActual($this->column)
-                ->withCondition($this);
-        }
-
-        // For some reason this is ok?
-        if (is_numeric($this->column) and !in_array($this->column, [0, 1])) {
-            $message = 'Column name cannot be numeric (except for 0 or 1)';
-            throw (new InvalidConditionException($message))
-                ->withActual($this->column)
-                ->withCondition($this);
-        }
-
-        Pdb::validateIdentifierExtended($this->column, true);
-
-        // If the value is a field type, then we should do validation there too.
-        if ($this->bind_type === Pdb::QUOTE_FIELD) {
-            if (is_iterable($this->value)) {
-                foreach ($this->value as $index => $value) {
-                    if (!is_scalar($value)) {
-                        $message = "Column array must be scalar (index {$index})";
-                        throw (new InvalidConditionException($message))
-                            ->withActual($value)
-                            ->withCondition($this);
-                    }
-                    Pdb::validateIdentifierExtended((string) $value, true);
-                }
-            }
-            else {
-                Pdb::validateIdentifierExtended((string) $this->value, true);
-            }
-        }
-    }
-
-
-    /**
-     * Build an appropriate SQL clause for this condition.
-     *
-     * The values will be created as ? and added to the $values parameter to
-     * permit one to bind the values later in an safe manner.
-     *
-     * @param Pdb $pdb
-     * @param array $values
-     * @return string
-     * @throws PDOException
-     * @throws InvalidConditionException
-     */
-    public function build(Pdb $pdb, array &$values): string
-    {
-        // String conditions are a lawless world.
-        if ($this->operator === null) {
-            return $this->value;
-        }
-
-        // Nested conditions!
-        if (
-            $this->column === null and
-            is_array($this->value)
-        ) {
-            $operator = $this->operator;
-            $compound = '';
-
-            // Special 'not' operator will perform a nested 'and'.
-            if ($operator === 'NOT') {
-                $operator = 'AND';
-                $compound .= 'NOT ';
-            }
-
-            $compound .= '(';
-            $first = true;
-
-            foreach ($this->value as $condition) {
-                if (!$first) {
-                    $compound .= " {$operator} ";
-                }
-
-                $compound .= $condition->build($pdb, $values);
-                $first = false;
-            }
-
-            $compound .= ')';
-            return $compound;
-        }
-
-        $column = $this->column;
-
-        // I'm not smart enough to auto-quote this.
-        if (!preg_match(PdbHelpers::RE_FUNCTION, $column)) {
-            $column = $pdb->quoteField($column);
-        }
-
-        switch ($this->operator) {
-            case self::EQUAL:
-            case self::NOT_EQUAL;
-            case self::NOT_EQUAL_ALT;
-            case self::GREATER_THAN_EQUAL:
-            case self::LESS_THAN_EQUAL:
-            case self::LESS_THAN:
-            case self::GREATER_THAN:
-
-                // Gonna 'bind' this one manually. Doesn't feel great.
-                if ($this->bind_type) {
-                    $value = $this->bind_type === Pdb::QUOTE_VALUE
-                        ? $pdb->format($this->value)
-                        : $this->value;
-
-                    if (!is_scalar($value)) {
-                        $message = "Operator {$this->operator} needs a scalar value";
-                        throw (new InvalidConditionException($message))
-                            ->withActual($this->value)
-                            ->withCondition($this);
-                    }
-
-                    $bind = $pdb->quote($value, $this->bind_type);
-                }
-                // Natural bindings. Good.
-                else {
-                    $values[] = $this->value;
-                    $bind = '?';
-                }
-
-                return "{$column} {$this->operator} {$bind}";
-
-            case self::IS:
-                $value = $this->value;
-
-                if (is_string($value)) {
-                    $value = strtoupper($value);
-
-                    if (!in_array(strtoupper($value), ['NULL', 'NOT NULL'])) {
-                        $value = false;
-                    }
-                }
-                else if ($value === null) {
-                    $value = 'NULL';
-                }
-                else {
-                    $value = false;
-                }
-
-                if ($value === false) {
-                    $message = "Operator IS value must be NULL or NOT NULL";
-                    throw (new InvalidConditionException($message))
-                        ->withActual($this->value)
-                        ->withCondition($this);
-                }
-
-                return "{$column} {$this->operator} {$value}";
-
-            case self::IS_NOT:
-                $value = $this->value;
-
-                if (is_string($value)) {
-                    $value = strtoupper($value);
-
-                    if ($value !== 'NULL') {
-                        $value = false;
-                    }
-                }
-                else if ($value === null) {
-                    $value = 'NULL';
-                }
-                else {
-                    $value = false;
-                }
-
-                if ($value === false) {
-                    $message = "Operator IS NOT value must be NULL";
-                    throw (new InvalidConditionException($message))
-                        ->withActual($this->value)
-                        ->withCondition($this);
-                }
-
-                return "{$column} {$this->operator} NULL";
-
-            case self::BETWEEN:
-                if (!is_array($this->value)) {
-                    $message = "Operator BETWEEN value must be an array of two scalars";
-                    throw (new InvalidConditionException($message))
-                        ->withActual($this->value)
-                        ->withCondition($this);
-                }
-
-                if (count($this->value) != 2) {
-                    $message = "Operator BETWEEN value must be an array of two scalars";
-                    throw (new InvalidConditionException($message))
-                        ->withActual(count($this->value))
-                        ->withCondition($this);
-                }
-
-                [$low, $high] = array_values($this->value);
-
-                if (!$this->bind_type) {
-                    $values[] = $low;
-                    $values[] = $high;
-                    $high = $low = '?';
-                }
-                else {
-                    if ($this->bind_type === Pdb::QUOTE_VALUE) {
-                        $high = $pdb->format($high);
-                        $low = $pdb->format($low);
-                    }
-
-                    if (!is_scalar($low) or !is_scalar($high)) {
-                        $message = "Operator BETWEEN value must be an array of two scalars";
-                        $actual = gettype($low) . ' and ' . gettype($high);
-                        throw (new InvalidConditionException($message))
-                            ->withActual($actual)
-                            ->withCondition($this);
-                    }
-
-                    $low = $pdb->quoteValue($low);
-                    $high = $pdb->quoteValue($high);
-                }
-
-                return "{$column} BETWEEN {$low} AND {$high}";
-
-            case self::IN:
-            case self::NOT_IN:
-                $items = $this->value;
-
-                if (!is_array($items)) {
-                    $message = "Operator {$this->operator} value must be an array of scalars";
-
-                    throw (new InvalidConditionException($message))
-                        ->withActual($items)
-                        ->withCondition($this);
-                }
-
-                if (empty($items)) return '';
-
-                if (!$this->bind_type) {
-                    $binds = PdbHelpers::bindPlaceholders(count($items));
-
-                    foreach ($items as $item) {
-                        $values[] = $item;
-                    }
-                }
-                else {
-                    foreach ($items as $index => &$item) {
-                        if ($this->bind_type === Pdb::QUOTE_VALUE) {
-                            $item = $pdb->format($item);
-                        }
-
-                        if (!is_scalar($item)) {
-                            $message = "Operator {$this->operator} value must be an array of scalars";
-                            throw (new InvalidConditionException($message))
-                                ->withActual(gettype($items) . " (index {$index})")
-                                ->withCondition($this);
-                        }
-
-                        $item = $pdb->quote($item, $this->bind_type);
-                    }
-                    unset($item);
-
-                    $binds = implode(', ', $items);
-                }
-
-                return "{$column} {$this->operator} ({$binds})";
-
-            case self::CONTAINS:
-                $bind = $this->quoteLike($pdb, $values);
-                return "{$column} LIKE CONCAT('%', {$bind}, '%')";
-
-            case self::BEGINS:
-                $bind = $this->quoteLike($pdb, $values);
-                return "{$column} LIKE CONCAT({$bind}, '%')";
-
-            case self::ENDS:
-                $bind = $this->quoteLike($pdb, $values);
-                return "{$column} LIKE CONCAT('%', {$bind})";
-
-            case self::IN_SET:
-                $bind = $this->quoteLike($pdb, $values);
-                return "FIND_IN_SET({$bind}, {$column}) > 0";
-
-            default:
-                $message = "Operator not implemented: {$this->operator}";
-                throw (new InvalidConditionException($message))
-                    ->withCondition($this);
-        }
-    }
-
-
-    private function quoteLike(Pdb $pdb, array &$values)
-    {
-        if (!$this->bind_type) {
-            $values[] = PdbHelpers::likeEscape($this->value);
-            return '?';
-        }
-        else {
-            $value = $this->bind_type === Pdb::QUOTE_VALUE
-                ? $pdb->format($this->value)
-                : $this->value;
-
-            if (!is_scalar($value)) {
-                $message = "Operator {$this->operator} value must be scalar";
-                throw (new InvalidConditionException($message))
-                    ->withActual($this->value)
-                    ->withCondition($this);
-            }
-
-            $value = PdbHelpers::likeEscape($value);
-            $value = $pdb->quote($value, $this->bind_type);
-            return $value;
-        }
-    }
-
-
-    public function getPreviewSql(): string
-    {
-        switch ($this->operator) {
-            case self::EQUAL:
-            case self::NOT_EQUAL;
-            case self::NOT_EQUAL_ALT;
-            case self::GREATER_THAN_EQUAL:
-            case self::LESS_THAN_EQUAL:
-            case self::LESS_THAN:
-            case self::GREATER_THAN:
-            case self::IS:
-            case self::IS_NOT:
-                return "{$this->column} {$this->operator} ?";
-
-            case self::BETWEEN:
-                return "{$this->column} BETWEEN ? AND ?";
-
-            case self::IN:
-            case self::NOT_IN:
-                return "{$this->column} {$this->operator} (...)";
-
-            case self::CONTAINS:
-                return "{$this->column} LIKE CONCAT('%', ?, '%')";
-
-            case self::BEGINS:
-                return "{$this->column} LIKE CONCAT(?, '%')";
-
-            case self::ENDS:
-                return "{$this->column} LIKE CONCAT('%', ?)";
-
-            case self::IN_SET:
-                return "FIND_IN_SET(?, {$this->column}) > 0";
-        }
-
-        return '';
-    }
-
-
-    /** @inheritdoc */
-    public function __toString()
-    {
-        $preview = $this->getPreviewSql();
-
-        if ($preview) {
-            return $preview;
-        }
-
-        $type = gettype($this->value);
-        return "[{$this->column}, {$this->operator}, {$type}]";
-    }
 }

--- a/src/Models/PdbCondition.php
+++ b/src/Models/PdbCondition.php
@@ -113,7 +113,7 @@ abstract class PdbCondition implements PdbConditionInterface
 
             if (is_array($item)) {
                 // Support for nested conditions.
-                if (in_array($modifier, PdbCompoundCondition::COMPOUNDS)) {
+                if (in_array($modifier, PdbCompoundCondition::OPERATORS)) {
                     $conditions = self::fromArray($item);
                     return new PdbCompoundCondition($modifier, $conditions);
                 }

--- a/src/Models/PdbCondition.php
+++ b/src/Models/PdbCondition.php
@@ -62,9 +62,13 @@ abstract class PdbCondition implements PdbConditionInterface
             // Modified key-style condition.
             // :: [OPERATOR, COLUMN => VALUE]
             if ($count == 2) {
-                // TODO this isn't a safe assumption.
-                /** @var string $operator */
                 $operator = array_shift($item);
+
+                if (!is_string($operator)) {
+                    $type = gettype($operator);
+                    throw new InvalidArgumentException("Operator must be a string, got: {$type} [array]");
+                }
+
                 $operator = trim(strtoupper($operator));
 
                 $column = key($item);

--- a/src/Models/PdbCondition.php
+++ b/src/Models/PdbCondition.php
@@ -36,7 +36,6 @@ abstract class PdbCondition implements PdbConditionInterface
      * @param PdbConditionInterface|array|string|int|float|null $item
      * @return PdbConditionInterface
      * @throws InvalidConditionException
-     * @throws InvalidArgumentException
      */
     public static function fromShorthand($key, $item)
     {
@@ -71,7 +70,7 @@ abstract class PdbCondition implements PdbConditionInterface
 
                 if (!is_string($operator)) {
                     $type = gettype($operator);
-                    throw new InvalidArgumentException("Operator must be a string, got: {$type} [array]");
+                    throw new InvalidConditionException("Operator must be a string, got: {$type} [array]");
                 }
 
                 $operator = trim(strtoupper($operator));
@@ -95,7 +94,7 @@ abstract class PdbCondition implements PdbConditionInterface
                 return new PdbSimpleCondition($operator, $column, $value);
             }
 
-            throw new InvalidArgumentException('Conditions must have 1, 2 or 3 items, not: ' . $count);
+            throw new InvalidConditionException('Conditions must have 1, 2 or 3 items, not: ' . $count);
         }
 
         // String-style conditions.
@@ -104,7 +103,7 @@ abstract class PdbCondition implements PdbConditionInterface
         // declare their intent. Exception can happen further up the call chain.
         //  e.g. in PdbQuery::join().
         if (is_numeric($key) and is_string($item)) {
-            throw new InvalidArgumentException('Cannot implicitly parse unsafe conditions, please use PdbRawCondition');
+            throw new InvalidConditionException('Cannot implicitly parse unsafe conditions, please use PdbRawCondition');
         }
 
         // Key-style conditions + nested conditions.
@@ -135,7 +134,7 @@ abstract class PdbCondition implements PdbConditionInterface
         }
 
         $type = gettype($item);
-        throw new InvalidArgumentException("Invalid condition: {$key} => {$type}");
+        throw new InvalidConditionException("Invalid condition: {$key} => {$type}");
     }
 
 

--- a/src/Models/PdbCondition.php
+++ b/src/Models/PdbCondition.php
@@ -16,7 +16,7 @@ use PDOException;
  *
  * @package karmabunny\pdb
  */
-class PdbCondition
+class PdbCondition implements PdbConditionInterface
 {
 
     const EQUAL = '=';
@@ -115,18 +115,18 @@ class PdbCondition
      * 2. [operator, column => value]
      * 3. [column => value]
      *
-     * The third is only for equality or IS NULL conditions.
+     * The third is only for equality, IN, IS NULL conditions.
      *
      * @param string|int $key
-     * @param PdbCondition|array|string|int|float|null $item
-     * @return PdbCondition
+     * @param PdbConditionInterface|array|string|int|float|null $item
+     * @return PdbConditionInterface
      * @throws InvalidConditionException
      * @throws InvalidArgumentException
      */
     public static function fromShorthand($key, $item)
     {
         // Pass-through.
-        if ($item instanceof static) {
+        if ($item instanceof PdbConditionInterface) {
             return clone $item;
         }
 
@@ -223,7 +223,7 @@ class PdbCondition
      * shorthand arrays.
      *
      * @param array $clauses
-     * @return PdbCondition[]
+     * @return PdbConditionInterface[]
      * @throws InvalidArgumentException
      */
     public static function fromArray(array $clauses)

--- a/src/Models/PdbCondition.php
+++ b/src/Models/PdbCondition.php
@@ -95,11 +95,11 @@ abstract class PdbCondition implements PdbConditionInterface
 
         // String-style conditions.
         // :: 'operator = value'
-        // - Particularly useful for joins.
-        // - NOT to be used for unescaped values. Stick to array or key style.
-        // - Doesn't support non-scalar values.
+        // We ask that users explicitly encode a PdbRawCondition object to
+        // declare their intent. Exception can happen further up the call chain.
+        //  e.g. in PdbQuery::join().
         if (is_numeric($key) and is_string($item)) {
-            return new PdbRawCondition($item);
+            throw new InvalidArgumentException('Cannot implicitly parse unsafe conditions, please use PdbRawCondition');
         }
 
         // Key-style conditions + nested conditions.

--- a/src/Models/PdbConditionInterface.php
+++ b/src/Models/PdbConditionInterface.php
@@ -37,7 +37,6 @@ interface PdbConditionInterface
      *
      * @return void
      * @throws InvalidConditionException
-     * @throws InvalidArgumentException
      */
     public function validate();
 

--- a/src/Models/PdbConditionInterface.php
+++ b/src/Models/PdbConditionInterface.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2021 Karmabunny
+ */
+
+namespace karmabunny\pdb\Models;
+
+use karmabunny\pdb\Exceptions\InvalidConditionException;
+use karmabunny\pdb\Pdb;
+use PDOException;
+
+/**
+ *
+ * @package karmabunny\pdb
+ */
+interface PdbConditionInterface
+{
+
+    /**
+     * Build an appropriate SQL clause for this condition.
+     *
+     * The values will be created as ? and added to the $values parameter to
+     * permit one to bind the values later in an safe manner.
+     *
+     * @param Pdb $pdb
+     * @param array $values
+     * @return string
+     * @throws PDOException
+     * @throws InvalidConditionException
+     */
+    public function build(Pdb $pdb, array &$values): string;
+
+
+    /**
+     * Validate this condition.
+     *
+     * @return void
+     * @throws InvalidConditionException
+     * @throws InvalidArgumentException
+     */
+    public function validate();
+
+
+    /**
+     *
+     * @return string
+     */
+    public function getPreviewSql(): string;
+
+}

--- a/src/Models/PdbRawCondition.php
+++ b/src/Models/PdbRawCondition.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2021 Karmabunny
+ */
+
+namespace karmabunny\pdb\Models;
+
+use karmabunny\pdb\Pdb;
+
+/**
+ *
+ * @package karmabunny\pdb
+ */
+class PdbRawCondition implements PdbConditionInterface
+{
+
+    /** @var string */
+    public $sql;
+
+    /** @var array */
+    public $params = [];
+
+
+    /**
+     * Create a condition.
+     *
+     * @param string $sql
+     * @param array $params
+     */
+    public function __construct(string $sql, array $params = [])
+    {
+        $this->sql = $sql;
+        $this->params = $params;
+    }
+
+
+    /** @inheritdoc */
+    public function build(Pdb $pdb, array &$values): string
+    {
+        $values = array_merge($values, $this->params);
+        return $this->sql;
+    }
+
+
+    /** @inheritdoc */
+    public function validate()
+    {
+    }
+
+
+    /** @inheritdoc */
+    public function getPreviewSql(): string
+    {
+        return $this->sql;
+    }
+
+
+    /** @inheritdoc */
+    public function __toString()
+    {
+        return $this->sql;
+    }
+}

--- a/src/Models/PdbSimpleCondition.php
+++ b/src/Models/PdbSimpleCondition.php
@@ -53,10 +53,10 @@ class PdbSimpleCondition implements PdbConditionInterface
         self::IN_SET,
     ];
 
-    /** @var string|null */
+    /** @var string */
     public $operator;
 
-    /** @var string|null */
+    /** @var string */
     public $column;
 
     /** @var mixed */
@@ -151,41 +151,6 @@ class PdbSimpleCondition implements PdbConditionInterface
     /** @inheritdoc */
     public function build(Pdb $pdb, array &$values): string
     {
-        // String conditions are a lawless world.
-        if ($this->operator === null) {
-            return $this->value;
-        }
-
-        // Nested conditions!
-        if (
-            $this->column === null and
-            is_array($this->value)
-        ) {
-            $operator = $this->operator;
-            $compound = '';
-
-            // Special 'not' operator will perform a nested 'and'.
-            if ($operator === 'NOT') {
-                $operator = 'AND';
-                $compound .= 'NOT ';
-            }
-
-            $compound .= '(';
-            $first = true;
-
-            foreach ($this->value as $condition) {
-                if (!$first) {
-                    $compound .= " {$operator} ";
-                }
-
-                $compound .= $condition->build($pdb, $values);
-                $first = false;
-            }
-
-            $compound .= ')';
-            return $compound;
-        }
-
         $column = $this->column;
 
         // I'm not smart enough to auto-quote this.

--- a/src/Models/PdbSimpleCondition.php
+++ b/src/Models/PdbSimpleCondition.php
@@ -9,7 +9,7 @@ namespace karmabunny\pdb\Models;
 use karmabunny\pdb\Exceptions\InvalidConditionException;
 use karmabunny\pdb\Pdb;
 use karmabunny\pdb\PdbHelpers;
-use karmabunny\pdb\PdbQuery;
+use karmabunny\pdb\PdbQueryInterface;
 
 /**
  *
@@ -146,7 +146,7 @@ class PdbSimpleCondition implements PdbConditionInterface
         }
 
         // Pre-validate the query, we'll turn of validation later to save effort.
-        if ($this->value instanceof PdbQuery) {
+        if ($this->value instanceof PdbQueryInterface) {
             switch ($this->operator) {
                 case self::IS:
                 case self::IS_NOT:
@@ -223,7 +223,7 @@ class PdbSimpleCondition implements PdbConditionInterface
                     $bind = $value->build($pdb, $values);
                 }
                 // Some nested queries.
-                else if ($value instanceof PdbQuery) {
+                else if ($value instanceof PdbQueryInterface) {
                     [$bind, $subValues] = $value->build(false);
                     $values = array_merge($values, $subValues);
                 }
@@ -345,7 +345,7 @@ class PdbSimpleCondition implements PdbConditionInterface
                 if (
                     !is_array($value)
                     and !$value instanceof PdbConditionInterface
-                    and !$value instanceof PdbQuery
+                    and !$value instanceof PdbQueryInterface
                 ) {
                     $message = "Operator {$this->operator} value must be an array of scalars";
 
@@ -359,7 +359,7 @@ class PdbSimpleCondition implements PdbConditionInterface
                 if ($value instanceof PdbConditionInterface) {
                     $binds = $value->build($pdb, $values);
                 }
-                else if ($value instanceof PdbQuery) {
+                else if ($value instanceof PdbQueryInterface) {
                     [$binds, $subValues] = $value->build(false);
                     $values = array_merge($values, $subValues);
                 }

--- a/src/Models/PdbSimpleCondition.php
+++ b/src/Models/PdbSimpleCondition.php
@@ -30,6 +30,7 @@ class PdbSimpleCondition implements PdbConditionInterface
     const BETWEEN = 'BETWEEN';
     const IN = 'IN';
     const NOT_IN = 'NOT IN';
+    const LIKE = 'LIKE';
     const CONTAINS = 'CONTAINS';
     const BEGINS = 'BEGINS';
     const ENDS = 'ENDS';
@@ -48,6 +49,7 @@ class PdbSimpleCondition implements PdbConditionInterface
         self::BETWEEN,
         self::IN,
         self::NOT_IN,
+        self::LIKE,
         self::CONTAINS,
         self::BEGINS,
         self::ENDS,
@@ -391,6 +393,10 @@ class PdbSimpleCondition implements PdbConditionInterface
                 }
 
                 return "{$column} {$this->operator} ({$binds})";
+
+            case self::LIKE:
+                $bind = $this->quoteLike($pdb, $values);
+                return "{$column} LIKE {$bind}";
 
             case self::CONTAINS:
                 $bind = $this->quoteLike($pdb, $values);

--- a/src/Models/PdbSimpleCondition.php
+++ b/src/Models/PdbSimpleCondition.php
@@ -1,0 +1,465 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2021 Karmabunny
+ */
+
+namespace karmabunny\pdb\Models;
+
+use karmabunny\pdb\Exceptions\InvalidConditionException;
+use karmabunny\pdb\Pdb;
+use karmabunny\pdb\PdbHelpers;
+
+/**
+ *
+ * @package karmabunny\pdb
+ */
+class PdbSimpleCondition implements PdbConditionInterface
+{
+
+    const EQUAL = '=';
+    const LESS_THAN_EQUAL = '<=';
+    const GREATER_THAN_EQUAL = '>=';
+    const LESS_THAN = '<';
+    const GREATER_THAN = '>';
+    const NOT_EQUAL = '!=';
+    const NOT_EQUAL_ALT = '<>';
+    const IS = 'IS';
+    const IS_NOT = 'IS NOT';
+    const BETWEEN = 'BETWEEN';
+    const IN = 'IN';
+    const NOT_IN = 'NOT IN';
+    const CONTAINS = 'CONTAINS';
+    const BEGINS = 'BEGINS';
+    const ENDS = 'ENDS';
+    const IN_SET = 'IN SET';
+
+    const OPERATORS = [
+        self::EQUAL,
+        self::LESS_THAN_EQUAL,
+        self::GREATER_THAN_EQUAL,
+        self::LESS_THAN,
+        self::GREATER_THAN,
+        self::NOT_EQUAL,
+        self::NOT_EQUAL_ALT,
+        self::IS,
+        self::IS_NOT,
+        self::BETWEEN,
+        self::IN,
+        self::NOT_IN,
+        self::CONTAINS,
+        self::BEGINS,
+        self::ENDS,
+        self::IN_SET,
+    ];
+
+    /** @var string|null */
+    public $operator;
+
+    /** @var string|null */
+    public $column;
+
+    /** @var mixed */
+    public $value;
+
+    /**
+     * This controls the bind method of the 'value'.
+     *
+     * - Given `null` this uses parametric binding. This is the safest method.
+     *
+     * - Use the `FIELD` type to treat the 'value' as a column/table type.
+     * This will apply the appropriate quoting method.
+     *
+     * - The `VALUE` type will use the PDO driver's 'quote()' method.
+     * However this is still not as safe as using natural bindings.
+     *
+     * @var string|null Pdb::QUOTE_FIELD|QUOTE_VALUE|null
+     **/
+    public $bind_type;
+
+    /**
+     * Create a condition.
+     *
+     * @param string $operator
+     * @param string $column
+     * @param mixed $value
+     * @param string|null $bind
+     */
+    public function __construct(string $operator, string $column, $value, string $bind = null)
+    {
+        $this->operator = trim(strtoupper($operator));
+        $this->column = $column;
+        $this->value = $value;
+        $this->bind_type = $bind;
+    }
+
+
+    /** @inheritdoc */
+    public function validate()
+    {
+        if (!is_scalar($this->operator)) {
+            $message = 'Invalid operator: ' . gettype($this->operator);
+                throw (new InvalidConditionException($message))
+                    ->withCondition($this);
+        }
+
+        if ($this->column !== null) {
+            if (!in_array($this->operator, self::OPERATORS)) {
+                $message = "Unknown operator: '{$this->operator}'";
+                throw (new InvalidConditionException($message))
+                    ->withCondition($this);
+            }
+        }
+
+        if (!is_scalar($this->column)) {
+            $message = 'Column name must be scalar';
+            throw (new InvalidConditionException($message))
+                ->withActual($this->column)
+                ->withCondition($this);
+        }
+
+        // For some reason this is ok?
+        if (is_numeric($this->column) and !in_array($this->column, [0, 1])) {
+            $message = 'Column name cannot be numeric (except for 0 or 1)';
+            throw (new InvalidConditionException($message))
+                ->withActual($this->column)
+                ->withCondition($this);
+        }
+
+        Pdb::validateIdentifierExtended($this->column, true);
+
+        // If the value is a field type, then we should do validation there too.
+        if ($this->bind_type === Pdb::QUOTE_FIELD) {
+            if (is_iterable($this->value)) {
+                foreach ($this->value as $index => $value) {
+                    if (!is_scalar($value)) {
+                        $message = "Column array must be scalar (index {$index})";
+                        throw (new InvalidConditionException($message))
+                            ->withActual($value)
+                            ->withCondition($this);
+                    }
+                    Pdb::validateIdentifierExtended((string) $value, true);
+                }
+            }
+            else {
+                Pdb::validateIdentifierExtended((string) $this->value, true);
+            }
+        }
+    }
+
+
+    /** @inheritdoc */
+    public function build(Pdb $pdb, array &$values): string
+    {
+        // String conditions are a lawless world.
+        if ($this->operator === null) {
+            return $this->value;
+        }
+
+        // Nested conditions!
+        if (
+            $this->column === null and
+            is_array($this->value)
+        ) {
+            $operator = $this->operator;
+            $compound = '';
+
+            // Special 'not' operator will perform a nested 'and'.
+            if ($operator === 'NOT') {
+                $operator = 'AND';
+                $compound .= 'NOT ';
+            }
+
+            $compound .= '(';
+            $first = true;
+
+            foreach ($this->value as $condition) {
+                if (!$first) {
+                    $compound .= " {$operator} ";
+                }
+
+                $compound .= $condition->build($pdb, $values);
+                $first = false;
+            }
+
+            $compound .= ')';
+            return $compound;
+        }
+
+        $column = $this->column;
+
+        // I'm not smart enough to auto-quote this.
+        if (!preg_match(PdbHelpers::RE_FUNCTION, $column)) {
+            $column = $pdb->quoteField($column);
+        }
+
+        switch ($this->operator) {
+            case self::EQUAL:
+            case self::NOT_EQUAL;
+            case self::NOT_EQUAL_ALT;
+            case self::GREATER_THAN_EQUAL:
+            case self::LESS_THAN_EQUAL:
+            case self::LESS_THAN:
+            case self::GREATER_THAN:
+
+                // Gonna 'bind' this one manually. Doesn't feel great.
+                if ($this->bind_type) {
+                    $value = $this->bind_type === Pdb::QUOTE_VALUE
+                        ? $pdb->format($this->value)
+                        : $this->value;
+
+                    if (!is_scalar($value)) {
+                        $message = "Operator {$this->operator} needs a scalar value";
+                        throw (new InvalidConditionException($message))
+                            ->withActual($this->value)
+                            ->withCondition($this);
+                    }
+
+                    $bind = $pdb->quote($value, $this->bind_type);
+                }
+                // Natural bindings. Good.
+                else {
+                    $values[] = $this->value;
+                    $bind = '?';
+                }
+
+                return "{$column} {$this->operator} {$bind}";
+
+            case self::IS:
+                $value = $this->value;
+
+                if (is_string($value)) {
+                    $value = strtoupper($value);
+
+                    if (!in_array(strtoupper($value), ['NULL', 'NOT NULL'])) {
+                        $value = false;
+                    }
+                }
+                else if ($value === null) {
+                    $value = 'NULL';
+                }
+                else {
+                    $value = false;
+                }
+
+                if ($value === false) {
+                    $message = "Operator IS value must be NULL or NOT NULL";
+                    throw (new InvalidConditionException($message))
+                        ->withActual($this->value)
+                        ->withCondition($this);
+                }
+
+                return "{$column} {$this->operator} {$value}";
+
+            case self::IS_NOT:
+                $value = $this->value;
+
+                if (is_string($value)) {
+                    $value = strtoupper($value);
+
+                    if ($value !== 'NULL') {
+                        $value = false;
+                    }
+                }
+                else if ($value === null) {
+                    $value = 'NULL';
+                }
+                else {
+                    $value = false;
+                }
+
+                if ($value === false) {
+                    $message = "Operator IS NOT value must be NULL";
+                    throw (new InvalidConditionException($message))
+                        ->withActual($this->value)
+                        ->withCondition($this);
+                }
+
+                return "{$column} {$this->operator} NULL";
+
+            case self::BETWEEN:
+                if (!is_array($this->value)) {
+                    $message = "Operator BETWEEN value must be an array of two scalars";
+                    throw (new InvalidConditionException($message))
+                        ->withActual($this->value)
+                        ->withCondition($this);
+                }
+
+                if (count($this->value) != 2) {
+                    $message = "Operator BETWEEN value must be an array of two scalars";
+                    throw (new InvalidConditionException($message))
+                        ->withActual(count($this->value))
+                        ->withCondition($this);
+                }
+
+                [$low, $high] = array_values($this->value);
+
+                if (!$this->bind_type) {
+                    $values[] = $low;
+                    $values[] = $high;
+                    $high = $low = '?';
+                }
+                else {
+                    if ($this->bind_type === Pdb::QUOTE_VALUE) {
+                        $high = $pdb->format($high);
+                        $low = $pdb->format($low);
+                    }
+
+                    if (!is_scalar($low) or !is_scalar($high)) {
+                        $message = "Operator BETWEEN value must be an array of two scalars";
+                        $actual = gettype($low) . ' and ' . gettype($high);
+                        throw (new InvalidConditionException($message))
+                            ->withActual($actual)
+                            ->withCondition($this);
+                    }
+
+                    $low = $pdb->quoteValue($low);
+                    $high = $pdb->quoteValue($high);
+                }
+
+                return "{$column} BETWEEN {$low} AND {$high}";
+
+            case self::IN:
+            case self::NOT_IN:
+                $items = $this->value;
+
+                if (!is_array($items)) {
+                    $message = "Operator {$this->operator} value must be an array of scalars";
+
+                    throw (new InvalidConditionException($message))
+                        ->withActual($items)
+                        ->withCondition($this);
+                }
+
+                if (empty($items)) return '';
+
+                if (!$this->bind_type) {
+                    $binds = PdbHelpers::bindPlaceholders(count($items));
+
+                    foreach ($items as $item) {
+                        $values[] = $item;
+                    }
+                }
+                else {
+                    foreach ($items as $index => &$item) {
+                        if ($this->bind_type === Pdb::QUOTE_VALUE) {
+                            $item = $pdb->format($item);
+                        }
+
+                        if (!is_scalar($item)) {
+                            $message = "Operator {$this->operator} value must be an array of scalars";
+                            throw (new InvalidConditionException($message))
+                                ->withActual(gettype($items) . " (index {$index})")
+                                ->withCondition($this);
+                        }
+
+                        $item = $pdb->quote($item, $this->bind_type);
+                    }
+                    unset($item);
+
+                    $binds = implode(', ', $items);
+                }
+
+                return "{$column} {$this->operator} ({$binds})";
+
+            case self::CONTAINS:
+                $bind = $this->quoteLike($pdb, $values);
+                return "{$column} LIKE CONCAT('%', {$bind}, '%')";
+
+            case self::BEGINS:
+                $bind = $this->quoteLike($pdb, $values);
+                return "{$column} LIKE CONCAT({$bind}, '%')";
+
+            case self::ENDS:
+                $bind = $this->quoteLike($pdb, $values);
+                return "{$column} LIKE CONCAT('%', {$bind})";
+
+            case self::IN_SET:
+                $bind = $this->quoteLike($pdb, $values);
+                return "FIND_IN_SET({$bind}, {$column}) > 0";
+
+            default:
+                $message = "Operator not implemented: {$this->operator}";
+                throw (new InvalidConditionException($message))
+                    ->withCondition($this);
+        }
+    }
+
+
+    private function quoteLike(Pdb $pdb, array &$values)
+    {
+        if (!$this->bind_type) {
+            $values[] = PdbHelpers::likeEscape($this->value);
+            return '?';
+        }
+        else {
+            $value = $this->bind_type === Pdb::QUOTE_VALUE
+                ? $pdb->format($this->value)
+                : $this->value;
+
+            if (!is_scalar($value)) {
+                $message = "Operator {$this->operator} value must be scalar";
+                throw (new InvalidConditionException($message))
+                    ->withActual($this->value)
+                    ->withCondition($this);
+            }
+
+            $value = PdbHelpers::likeEscape($value);
+            $value = $pdb->quote($value, $this->bind_type);
+            return $value;
+        }
+    }
+
+
+    /** @inheritdoc */
+    public function getPreviewSql(): string
+    {
+        switch ($this->operator) {
+            case self::EQUAL:
+            case self::NOT_EQUAL;
+            case self::NOT_EQUAL_ALT;
+            case self::GREATER_THAN_EQUAL:
+            case self::LESS_THAN_EQUAL:
+            case self::LESS_THAN:
+            case self::GREATER_THAN:
+            case self::IS:
+            case self::IS_NOT:
+                return "{$this->column} {$this->operator} ?";
+
+            case self::BETWEEN:
+                return "{$this->column} BETWEEN ? AND ?";
+
+            case self::IN:
+            case self::NOT_IN:
+                return "{$this->column} {$this->operator} (...)";
+
+            case self::CONTAINS:
+                return "{$this->column} LIKE CONCAT('%', ?, '%')";
+
+            case self::BEGINS:
+                return "{$this->column} LIKE CONCAT(?, '%')";
+
+            case self::ENDS:
+                return "{$this->column} LIKE CONCAT('%', ?)";
+
+            case self::IN_SET:
+                return "FIND_IN_SET(?, {$this->column}) > 0";
+        }
+
+        return '';
+    }
+
+
+    /** @inheritdoc */
+    public function __toString()
+    {
+        $preview = $this->getPreviewSql();
+
+        if ($preview) {
+            return $preview;
+        }
+
+        $type = gettype($this->value);
+        return "[{$this->column}, {$this->operator}, {$type}]";
+    }
+}

--- a/src/Models/PdbSimpleCondition.php
+++ b/src/Models/PdbSimpleCondition.php
@@ -130,9 +130,8 @@ class PdbSimpleCondition implements PdbConditionInterface
 
         // Validate nested conditions.
         if ($this->value instanceof PdbConditionInterface) {
-            $this->value->validate();
 
-            // Also double check what operator we've paired it with.
+            // But first check what operator we've paired it with.
             switch ($this->operator) {
                 case self::IS:
                 case self::IS_NOT:
@@ -141,6 +140,8 @@ class PdbSimpleCondition implements PdbConditionInterface
                     throw (new InvalidConditionException($message))
                         ->withCondition($this);
             }
+
+            $this->value->validate();
         }
 
         // If the value is a field type, then we should do validation there too.

--- a/src/Pdb.php
+++ b/src/Pdb.php
@@ -25,6 +25,7 @@ use karmabunny\pdb\Drivers\PdbNoDriver;
 use karmabunny\pdb\Drivers\PdbPgsql;
 use karmabunny\pdb\Drivers\PdbSqlite;
 use karmabunny\pdb\Exceptions\ConnectionException;
+use karmabunny\pdb\Exceptions\InvalidConditionException;
 use karmabunny\pdb\Exceptions\PdbException;
 use karmabunny\pdb\Models\PdbColumn;
 use karmabunny\pdb\Models\PdbCondition;

--- a/src/Pdb.php
+++ b/src/Pdb.php
@@ -758,6 +758,7 @@ abstract class Pdb implements Loggable, Serializable, NotSerializable
      * @param array $values Array of bind parameters. Additional parameters will be appended to this array
      * @param string $combine String to be placed between the conditions. Must be one of: 'AND', 'OR', 'XOR'
      * @return string A clause which is safe to use in a prepared SQL statement
+     * @throws InvalidConditionException
      * @throws InvalidArgumentException
      * @example
      * $conditions = ['active' => 1, ['date_added', 'BETWEEN', ['2015-01-01', '2016-01-01']]];
@@ -777,23 +778,7 @@ abstract class Pdb implements Loggable, Serializable, NotSerializable
      */
     public function buildClause(array $conditions, array &$values, $combine = 'AND')
     {
-        if ($combine != 'AND' and $combine != 'OR' and $combine != 'XOR') {
-            throw new InvalidArgumentException('Combine parameter must be of of: "AND", "OR", "XOR"');
-        }
-
-        $conditions = PdbCondition::fromArray($conditions);
-        $combine = " {$combine} ";
-        $where = '';
-
-        foreach ($conditions as $condition) {
-            $clause = $condition->build($this, $values);
-            if (!$clause) continue;
-
-            if ($where) $where .= $combine;
-            $where .= $clause;
-        }
-
-        return $where;
+        return PdbCondition::buildClause($this, $conditions, $values, $combine, true);
     }
 
 

--- a/src/PdbQuery.php
+++ b/src/PdbQuery.php
@@ -296,7 +296,7 @@ class PdbQuery implements PdbQueryInterface, Arrayable, JsonSerializable
      *
      * @param string $type
      * @param string|string[] $table
-     * @param string|PdbConditionInterface|(array|PdbConditionInterface)[] $conditions
+     * @param string|PdbConditionInterface|(array|string|PdbConditionInterface)[] $conditions
      * @param string $combine
      * @return static
      * @throws InvalidArgumentException
@@ -307,7 +307,7 @@ class PdbQuery implements PdbQueryInterface, Arrayable, JsonSerializable
         Pdb::validateAlias($table);
 
         if (is_string($conditions)) {
-            [ $conditions ] = new PdbRawCondition($conditions);
+            $conditions = [ new PdbRawCondition($conditions) ];
         }
         else if ($conditions instanceof PdbConditionInterface) {
             $conditions = [ $conditions ];

--- a/src/PdbQuery.php
+++ b/src/PdbQuery.php
@@ -644,6 +644,27 @@ class PdbQuery implements Arrayable, JsonSerializable
 
     /**
      *
+     * @return void
+     * @throws InvalidConditionException
+     */
+    public function validate()
+    {
+        foreach ($this->_joins as $item) {
+            PdbCondition::fromArray($item[2], true);
+        }
+
+        foreach ($this->_where as $item) {
+            PdbCondition::fromArray($item[1], true);
+        }
+
+        foreach ($this->_having as $item) {
+            PdbCondition::fromArray($item[1], true);
+        }
+    }
+
+
+    /**
+     *
      * @return array [ sql, params ]
      * @throws InvalidArgumentException
      */

--- a/src/PdbQuery.php
+++ b/src/PdbQuery.php
@@ -14,7 +14,7 @@ use karmabunny\kb\Arrayable;
 use karmabunny\kb\Arrays;
 use karmabunny\pdb\Exceptions\ConnectionException;
 use karmabunny\pdb\Exceptions\QueryException;
-use karmabunny\pdb\Models\PdbCondition;
+use karmabunny\pdb\Models\PdbConditionInterface;
 use karmabunny\pdb\Models\PdbReturn;
 use PDOStatement;
 use PDO;
@@ -293,7 +293,7 @@ class PdbQuery implements Arrayable, JsonSerializable
      *
      * @param string $type
      * @param string|string[] $table
-     * @param (array|string|PdbCondition)[] $conditions
+     * @param (array|string|PdbConditionInterface)[] $conditions
      * @param string $combine
      * @return static
      * @throws InvalidArgumentException
@@ -311,7 +311,7 @@ class PdbQuery implements Arrayable, JsonSerializable
     /**
      *
      * @param string|string[] $table
-     * @param (array|string|PdbCondition)[] $conditions
+     * @param (array|string|PdbConditionInterface)[] $conditions
      * @param string $combine
      * @return static
      */
@@ -324,7 +324,7 @@ class PdbQuery implements Arrayable, JsonSerializable
     /**
      *
      * @param string|string[] $table
-     * @param (array|string|PdbCondition)[] $conditions
+     * @param (array|string|PdbConditionInterface)[] $conditions
      * @param string $combine
      * @return static
      */
@@ -338,7 +338,7 @@ class PdbQuery implements Arrayable, JsonSerializable
     /**
      *
      * @param string|string[] $table
-     * @param (array|string|PdbCondition)[] $conditions
+     * @param (array|string|PdbConditionInterface)[] $conditions
      * @param string $combine
      * @return static
      */
@@ -351,7 +351,7 @@ class PdbQuery implements Arrayable, JsonSerializable
 
     /**
      *
-     * @param (array|string|PdbCondition)[] $conditions
+     * @param (array|string|PdbConditionInterface)[] $conditions
      * @param string $combine
      * @return static
      */
@@ -367,7 +367,7 @@ class PdbQuery implements Arrayable, JsonSerializable
 
     /**
      *
-     * @param (array|string|PdbCondition)[] $conditions
+     * @param (array|string|PdbConditionInterface)[] $conditions
      * @param string $combine AND | OR
      * @return static
      */
@@ -382,7 +382,7 @@ class PdbQuery implements Arrayable, JsonSerializable
 
     /**
      *
-     * @param (array|string|PdbCondition)[] $conditions
+     * @param (array|string|PdbConditionInterface)[] $conditions
      * @param string $combine AND | OR
      * @return static
      */
@@ -397,7 +397,7 @@ class PdbQuery implements Arrayable, JsonSerializable
 
     /**
      *
-     * @param (array|string|PdbCondition)[] $conditions
+     * @param (array|string|PdbConditionInterface)[] $conditions
      * @param string $combine
      * @return static
      */

--- a/src/PdbQuery.php
+++ b/src/PdbQuery.php
@@ -13,6 +13,7 @@ use JsonSerializable;
 use karmabunny\kb\Arrayable;
 use karmabunny\kb\Arrays;
 use karmabunny\pdb\Exceptions\ConnectionException;
+use karmabunny\pdb\Exceptions\InvalidConditionException;
 use karmabunny\pdb\Exceptions\QueryException;
 use karmabunny\pdb\Models\PdbCondition;
 use karmabunny\pdb\Models\PdbConditionInterface;

--- a/src/PdbQuery.php
+++ b/src/PdbQuery.php
@@ -73,7 +73,7 @@ use ReturnTypeWillChange;
  *
  * @package karmabunny\pdb
  */
-class PdbQuery implements Arrayable, JsonSerializable
+class PdbQuery implements PdbQueryInterface, Arrayable, JsonSerializable
 {
 
     /** @var Pdb */

--- a/src/PdbQueryInterface.php
+++ b/src/PdbQueryInterface.php
@@ -6,7 +6,7 @@
 
 namespace karmabunny\pdb;
 
-use InvalidArgumentException;
+use karmabunny\pdb\Exceptions\InvalidConditionException;
 
 /**
  *
@@ -27,8 +27,6 @@ interface PdbQueryInterface
      *
      * @param bool $validate
      * @return array [ sql, params ]
-     * @throws InvalidConditionException
-     * @throws InvalidArgumentException
      */
     public function build(bool $validate = true): array;
 

--- a/src/PdbQueryInterface.php
+++ b/src/PdbQueryInterface.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link      https://github.com/Karmabunny
+ * @copyright Copyright (c) 2021 Karmabunny
+ */
+
+namespace karmabunny\pdb;
+
+use InvalidArgumentException;
+
+/**
+ *
+ * @package karmabunny\pdb
+ */
+interface PdbQueryInterface
+{
+
+    /**
+     *
+     * @return void
+     * @throws InvalidConditionException
+     */
+    public function validate();
+
+
+    /**
+     *
+     * @param bool $validate
+     * @return array [ sql, params ]
+     * @throws InvalidConditionException
+     * @throws InvalidArgumentException
+     */
+    public function build(bool $validate = true): array;
+
+}

--- a/tests/PdbConditionTest.php
+++ b/tests/PdbConditionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use karmabunny\pdb\Models\PdbCondition;
+use karmabunny\pdb\Models\PdbSimpleCondition;
 use karmabunny\pdb\Pdb;
 use kbtests\Database;
 use PHPUnit\Framework\TestCase;
@@ -13,7 +14,7 @@ class PdbConditionTest extends TestCase
     {
         $pdb = Database::getConnection();
 
-        $condition = new PdbCondition('=', 'abc.def', 1234);
+        $condition = new PdbSimpleCondition('=', 'abc.def', 1234);
 
         $values = [];
         $clause = $condition->build($pdb, $values);
@@ -150,8 +151,8 @@ class PdbConditionTest extends TestCase
         $pdb = Database::getConnection();
         if (!Database::isConnected()) $this->markTestSkipped();
 
-        $condition = new PdbCondition(
-            PdbCondition::NOT_IN,
+        $condition = new PdbSimpleCondition(
+            PdbSimpleCondition::NOT_IN,
             'what.total',
             ['bollocks', 'mouth protection'],
             Pdb::QUOTE_VALUE
@@ -170,8 +171,8 @@ class PdbConditionTest extends TestCase
         $pdb = Database::getConnection();
         if (!Database::isConnected()) $this->markTestSkipped();
 
-        $condition = new PdbCondition(
-            PdbCondition::NOT_IN,
+        $condition = new PdbSimpleCondition(
+            PdbSimpleCondition::NOT_IN,
             'what.total',
             ['bollocks', 'mouth_protection'],
             Pdb::QUOTE_FIELD

--- a/tests/PdbConditionTest.php
+++ b/tests/PdbConditionTest.php
@@ -120,7 +120,7 @@ class PdbConditionTest extends TestCase
         $pdb = Database::getConnection();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/unsafe conditions/');
+        $this->expectExceptionMessageMatches('/Invalid string condition/i');
 
         $conditions = PdbCondition::fromArray([
             'big.stuff <= little.stuff',

--- a/tests/PdbConditionTest.php
+++ b/tests/PdbConditionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use karmabunny\pdb\Models\PdbCondition;
+use karmabunny\pdb\Models\PdbRawCondition;
 use karmabunny\pdb\Models\PdbSimpleCondition;
 use karmabunny\pdb\Pdb;
 use kbtests\Database;
@@ -113,15 +114,31 @@ class PdbConditionTest extends TestCase
     }
 
 
+    public function testBadStrings(): void
+    {
+        $pdb = Database::getConnection();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/unsafe conditions/');
+
+        $conditions = PdbCondition::fromArray([
+            'big.stuff <= little.stuff',
+        ]);
+
+        $values = [];
+        $conditions[0]->build($pdb, $values);
+    }
+
+
     public function testStrings(): void
     {
         $pdb = Database::getConnection();
 
         $conditions = PdbCondition::fromArray([
-            'big.stuff <= little.stuff',
-            'you_better_hope_you >= \'have escaped this\'',
-            'what.will <> this_do',
-            '~prefix in (~voodoo.magic, ~stuff.id)',
+            new PdbRawCondition('big.stuff <= little.stuff'),
+            new PdbRawCondition('you_better_hope_you >= \'have escaped this\''),
+            new PdbRawCondition('what.will <> this_do'),
+            new PdbRawCondition('~prefix in (~voodoo.magic, ~stuff.id)'),
         ]);
 
         $this->assertCount(4, $conditions);


### PR DESCRIPTION
This splits our big complicated `PdbCondition` into an interface and sub classes for each concept.

- `PdbSimpleCondition` - what we know and love (basically everything in Sprout)
- `PdbCompoundCondition` - negations and nested magic for AND/OR
- `PdbRawCondition` - unmitigated disasters using raw SQL

The interface gives a rigidity for Pdb internals, but also something more concrete for consumers to write their own custom conditions. This could be JSON expressions, wrapping SQL functions, or some other magic.

The original `PdbCondition` class becomes abstract but retains the shorthand parser. Hopefully no-one is extending `PdbCondition` but at least that'll keep working as well as any other references to it. However invocations of `new PdbCondition()` will break, I hope that's acceptable. Sprout certainly doesn't have any.

We've removed raw SQL from the shorthand parser. This will improve safety. If we want to write raw SQL we can explicitly use the PdbRawCondition to indicate our intent of being unsafe.

```php
$query->where([
   ['date_added', '>', Pdb::now()],
   new PdbRawCondition('firstname = CONCAT(?, surname)' [$name]),
]);
```

Some minor adjustment to the `PdbQuery` joiners was necessary to support the new 'raw' sub class. At the same time, we can support syntax like this, which is hopefully more ergonomic.

```php
$query->innerJoin('other_table', 'my_table.other_id = other_table.id');
```
