### PR TITLE
Feat/timezones

### DIFF
--- a/src/PdbConfig.php
+++ b/src/PdbConfig.php
@@ -195,6 +195,15 @@ class PdbConfig extends Collection
     public $dsn;
 
     /**
+     * Use the PHP timezone for `Pdb::now()`.
+     *
+     * This also sets the session timezone to match.
+     *
+     * @var bool
+     */
+    public $use_system_timezone = true;
+
+    /**
      * Session variables per call to `connect()`.
      *
      * These are driver specific.

--- a/tests/BasePdbCase.php
+++ b/tests/BasePdbCase.php
@@ -110,4 +110,18 @@ abstract class BasePdbCase extends TestCase
         $expected = $table->columns;
         $this->assertEquals($expected, $columns);
     }
+
+
+    public function testTimezoneNow(): void
+    {
+        $now = $this->pdb->now();
+        $this->assertMatchesRegularExpression('/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/', $now);
+
+        $now = $this->pdb->now('Y-m-d');
+        $this->assertMatchesRegularExpression('/\d{4}-\d{2}-\d{2}/', $now);
+
+        $actual = $this->pdb->getTimezone();
+        $expected = date_default_timezone_get();
+        $this->assertEquals($expected, $actual->getName());
+    }
 }

--- a/tests/Models/DirtyClub.php
+++ b/tests/Models/DirtyClub.php
@@ -33,7 +33,7 @@ class DirtyClub extends Model
         $data = $this->getChecksums()->getAllDirty();
         unset($data['id']);
 
-        $now = Pdb::now();
+        $now = $this->getConnection()->now();
 
         if (!$this->id) {
             $data['date_added'] = $now;

--- a/tests/Models/Model.php
+++ b/tests/Models/Model.php
@@ -31,7 +31,7 @@ abstract class Model extends Record
     public function getSaveData(): array
     {
         $data = parent::getSaveData();
-        $now = Pdb::now();
+        $now = $this->getConnection()->now();
 
         if (!$this->id) {
             $data['date_added'] = $now;

--- a/tests/Models/SproutModel.php
+++ b/tests/Models/SproutModel.php
@@ -20,7 +20,7 @@ abstract class SproutModel extends Record
 
         $pdb = static::getConnection();
         $table = static::getTableName();
-        $now = Pdb::now();
+        $now = $pdb->now();
 
         // Include the uuid if it's not already set.
         // This may return NIL, that's OK - we do an insert + update later.

--- a/tests/PdbModelTest.php
+++ b/tests/PdbModelTest.php
@@ -51,7 +51,7 @@ class PdbModelTest extends TestCase
         $model = new Club();
         $model->name = 'thingo';
         $model->status = 'new';
-        $model->founded = Pdb::now();
+        $model->founded = $model->getConnection()->now();
 
         $expected = [
             'active',
@@ -122,7 +122,7 @@ class PdbModelTest extends TestCase
         $model = new DirtyClub();
         $model->name = 'thingo';
         $model->status = 'new';
-        $model->founded = Pdb::now();
+        $model->founded = $model->getConnection()->now();
 
         $expected = [
             'active',


### PR DESCRIPTION
Pdb is now timezone aware.

To be fair, the DB was always aware but now Pdb is able to align system + db timezones.

This means `::now()` is now (lol) is a non-static method. For Sprout there is likely no breaking change here. It already uses the static wrapper for most of it's pdb operations.

This should make Pdb more appropriate when migrating sites using the MySQL `NOW()` functions. This means the global database TZ doesn't need to match the PHP/application TZ because Pdb automatically applies a session timezone to match the application.

However, different projects have different requirements and issues, so this is all exposed via configurations. Should anyone need a mixed environment, a combination of `use_system_timezone` and the `session.time_zone` config will do the trick.

`Pdb::now()` also gets a date formatter param for convenience. You're welcome.