### PR TITLE
Sub queries

### DIFF
--- a/guides/query-builder.md
+++ b/guides/query-builder.md
@@ -55,9 +55,9 @@ This is the second-half of the `query()` method. executes a prepared statement a
 
 ## Shorthand helpers
 
-> `Pdb::get($table, $id): array`
+> `Pdb::get($table, $id, $throw = true): array`
 
-This fetches a table row by ID. If the row doesn't exit it throws a `RowMissingException`.
+This fetches a table row by ID. Given `$throw` it raises `RowMissingException` if the row is missing.
 
 
 > `Pdb::lookup($table, $conditions, $order, $name): array`
@@ -212,6 +212,16 @@ Set the offset of a query.
 Specify `offset(null)` to clear an existing offset.
 
 
+> `with($subQuery, $alias)`
+
+Prefix the query with `WITH alias AS (...)`.
+
+
+> `union($query)`
+
+Perform a union with this query.
+
+
 > `find($table, $conditions)`
 
 This is a shorthand that combines the filters `->from($table)->where($conditions)`.
@@ -234,6 +244,7 @@ Valid terminators:
 - `keyed(): object[]`
 - `iterator(): iterable<object>`
 - `batch($size): iterable<object[]>`
+- `each($size): iterable<object>`
 
 
 > `cache($key, $ttl)`
@@ -337,6 +348,11 @@ can build classes
 
 
 > `batch($size): iterable<array>`
+
+can build classes
+
+
+> `each($size): iterable<array>`
 
 can build classes
 

--- a/src/Compat/StaticPdb.php
+++ b/src/Compat/StaticPdb.php
@@ -17,6 +17,7 @@ use karmabunny\pdb\Pdb;
 use karmabunny\pdb\PdbConfig;
 use karmabunny\pdb\PdbHelpers;
 use karmabunny\pdb\PdbQuery;
+use karmabunny\pdb\PdbQueryInterface;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -44,7 +45,7 @@ use PDOStatement;
  * @method static int update(string $table, array $data, array $conditions)
  * @method static int delete(string $table, array $conditions)
  * @method static int upsert(string $table, array $data, array $conditions)
- * @method static PdbQuery find(string $table, array $conditions = [])
+ * @method static PdbQuery find(string|string[]|PdbQueryInterface $table, array $conditions = [])
  * @method static bool inTransaction()
  * @method static PdbTransaction transact()
  * @method static mixed withTransaction(callable $callback)

--- a/src/Pdb.php
+++ b/src/Pdb.php
@@ -1998,7 +1998,7 @@ abstract class Pdb implements Loggable, Serializable, NotSerializable
      *
      * An 'alias' in pdb is represented as an array pair: field, alias.
      *
-     * @param string|string[] $field
+     * @param string|array{0:mixed,1?:string} $field
      * @param bool $loose Permit integers/functions, e.g. SELECT 1, COUNT(*), etc
      * @return void
      * @throws InvalidArgumentException
@@ -2012,7 +2012,9 @@ abstract class Pdb implements Loggable, Serializable, NotSerializable
             [$field, $alias] = $field + [null, null];
         }
 
-        Pdb::validateIdentifierExtended($field, $loose);
+        if (is_scalar($field)) {
+            Pdb::validateIdentifierExtended($field, $loose);
+        }
 
         if ($alias) {
             Pdb::validateIdentifier($alias);

--- a/src/Pdb.php
+++ b/src/Pdb.php
@@ -1088,7 +1088,7 @@ abstract class Pdb implements Loggable, Serializable, NotSerializable
     /**
      * Shorthand for creating a new PdbQuery.
      *
-     * @param string|string[] $table
+     * @param string|string[]|PdbQueryInterface $table
      * @param array $conditions
      * @return PdbQuery
      */

--- a/src/PdbHelpers.php
+++ b/src/PdbHelpers.php
@@ -204,7 +204,7 @@ class PdbHelpers
      * - `'column as alias'` (string, full syntax)
      * - `'column alias'` (string, shorthand)
      *
-     * @param string|string[] $field
+     * @param string|PdbQueryInterface|array $field
      * @return array [ field, alias ] second param is null if no alias is present.
      */
     public static function parseAlias($field): array
@@ -225,6 +225,10 @@ class PdbHelpers
 
             // Convert [ alias => column ] to [ column, alias ]
             return [ $value, $key ];
+        }
+
+        if ($field instanceof PdbQueryInterface) {
+            return [$field, null];
         }
 
         // Convert 'column as alias' to [ column, alias ]

--- a/src/PdbQuery.php
+++ b/src/PdbQuery.php
@@ -624,7 +624,7 @@ class PdbQuery implements PdbQueryInterface, Arrayable, JsonSerializable
 
     /**
      *
-     * @param string|string[] $table
+     * @param string|string[]|PdbQueryInterface $table
      * @param array $conditions
      * @return static
      */

--- a/src/PdbQuery.php
+++ b/src/PdbQuery.php
@@ -300,7 +300,7 @@ class PdbQuery implements PdbQueryInterface, Arrayable, JsonSerializable
      */
     public function from($table, ?string $alias = null)
     {
-        if (!$alias and is_array($table)) {
+        if (!$alias) {
             [$table, $alias] = PdbHelpers::parseAlias($table);
         }
 

--- a/tests/PdbQueryTest.php
+++ b/tests/PdbQueryTest.php
@@ -268,4 +268,21 @@ class PdbQueryTest extends TestCase
     }
 
 
+    public function testUnions(): void
+    {
+        $query1 = $this->pdb->find('mmm')
+            ->select('id, name');
+
+        $query2 = $this->pdb->find('ahh')
+            ->select('id, name');
+
+        $query = $query1->union($query2);
+
+        [$sql, $params] = $query->build();
+
+        $expected = 'SELECT "id", "name" FROM "pdb_mmm"';
+        $expected .= "\nUNION\n";
+        $expected .= 'SELECT "id", "name" FROM "pdb_ahh"';
+        $this->assertEquals($expected, $sql);
+    }
 }

--- a/tests/PdbQueryTest.php
+++ b/tests/PdbQueryTest.php
@@ -246,4 +246,26 @@ class PdbQueryTest extends TestCase
         $this->assertEquals($expected, $sql);
     }
 
+
+    public function testWithQuery(): void
+    {
+        $query2 = $this->pdb->find('ahh');
+
+        $query1 = $this->pdb->find('mmm')
+            ->alias('mmm')
+            ->innerJoin('sub', 'mmm.id = sub._id')
+            ->with($query2, 'sub');
+
+        // Modify after attaching.
+        $query2->select('id as _id')
+            ->where(['name' => 'test']);
+
+        [$sql, $params] = $query1->build();
+
+        $expected = 'WITH "sub" AS (SELECT "id" AS "_id" FROM "pdb_ahh" WHERE "name" = ?)' . "\n";
+        $expected .= 'SELECT "mmm".* FROM "pdb_mmm" AS "mmm" INNER JOIN "sub" ON "mmm"."id" = "sub"."_id"';
+        $this->assertEquals($expected, $sql);
+    }
+
+
 }

--- a/tests/PdbQueryTest.php
+++ b/tests/PdbQueryTest.php
@@ -23,6 +23,15 @@ class PdbQueryTest extends TestCase
         $this->pdb->query('DROP TABLE IF EXISTS ~mmm', [], 'null');
     }
 
+
+    public function testSerialize(): void
+    {
+        // Remove underscores from internal properties?
+        // Serialize/unserialise with nested queries, condition objects.
+        $this->markTestSkipped('TODO');
+    }
+
+
     public function testSelect(): void
     {
         $query = $this->pdb->find('mmm')

--- a/tests/PdbQueryTest.php
+++ b/tests/PdbQueryTest.php
@@ -2,6 +2,7 @@
 
 use karmabunny\pdb\Pdb;
 use karmabunny\pdb\PdbConfig;
+use karmabunny\pdb\PdbQuery;
 use PHPUnit\Framework\TestCase;
 
 
@@ -226,6 +227,22 @@ class PdbQueryTest extends TestCase
         $expected .= 'FROM "pdb_stuff" ';
         $expected .= 'INNER JOIN "pdb_more" AS "mmm" ';
         $expected .= 'ON "pdb_stuff"."id" = "mmm"."stuff_id"';
+        $this->assertEquals($expected, $sql);
+    }
+
+
+    public function testFromSubQuery(): void
+    {
+        $subQuery = $this->pdb->find('ahh')
+            ->where(['name' => 'test'])
+            ->select('id, name AS title');
+
+        $query = (new PdbQuery($this->pdb))
+            ->from($subQuery, 'ahh');
+
+        [$sql, $params] = $query->build();
+
+        $expected = 'SELECT "ahh".* FROM (SELECT "id", "name" AS "title" FROM "pdb_ahh" WHERE "name" = ?) AS "ahh"';
         $this->assertEquals($expected, $sql);
     }
 


### PR DESCRIPTION
All those fancy things we dreamed about!

This is subquery nested in the FRON statement like `SELECT * FROM (...) AS subQuery`.
```php
$subQuery = new PdbQuery($pdb);

$query = (new PdbQuery($pdb))
    ->from($subQuery, 'foo');

$subQuery->from('bar')
    ->where(['name' => 'test'])
    ->select('id, category');
```

Some of the key magic here is that the subQuery isn't built or validated until the parent query is built. Meaning you're free to modify that object after attaching it to the parent.

This is a subquery using the `WITH` statement, which is somewhat like a temporary/inline VIEW.

```php
$subQuery = $pdb->find('foo')
    ->select('id as _id')
    ->where(['name' => 'test']);

$query = $pdb->find('foo')
   ->innerJoin('sub', '~foo.id = sub._id')
   ->with($subQuery, 'sub');
```

Union also exists now, but that's pretty boring.

Having said all that. This PR description should go straight into some docs.

The test cases also need some real executed queries. Not just generated SQL.