### PR TITLE
Fix: CONTAINS condition fails to match a value containing a backslash

### DIFF
--- a/src/Compat/StaticPdb.php
+++ b/src/Compat/StaticPdb.php
@@ -65,7 +65,7 @@ use PDOStatement;
  * @method static string prettyQueryIndentation(string $query)
  * @method static string prettyQuery(string $query, array $values)
  * @method static string stripStrings(string $q)
- * @method static string likeEscape(string $str)
+ * @method static string likeEscape(string $str, string $escape = '\\')
  * @method static array convertEnumArr(string $enum_defn)
  *
  * @method static string quote(string $field, string $type)

--- a/src/PdbHelpers.php
+++ b/src/PdbHelpers.php
@@ -169,6 +169,7 @@ class PdbHelpers
         return strtr($str, [
             '%' => $escape . '%',
             '_' => $escape . '_',
+            '\\' => $escape . '\\',
         ]);
     }
 

--- a/tests/StaticPdbTest.php
+++ b/tests/StaticPdbTest.php
@@ -713,4 +713,23 @@ class StaticPdbTest extends TestCase
 
     }
 
+
+    public static function dataLikeEscape()
+    {
+        return [
+            '' => ['%foo\\bar_baz', '\\', '\%foo\\\\bar\\_baz'],
+            '%' =>['%foo\\bar_baz', '%', '%%foo%\\bar%_baz'],
+            '_' =>['%foo\\bar_baz', '_', '_%foo_\\bar__baz'],
+            '!' =>['%foo\\bar_baz', '!', '!%foo!\\bar!_baz'],
+        ];
+    }
+
+
+    /**
+     * @dataProvider dataLikeEscape
+     */
+    public function testLikeEscape($str, $escape, $expected)
+    {
+        $this->assertEquals($expected, Pdb::likeEscape($str, $escape));
+    }
 }


### PR DESCRIPTION
E.g.

```php
Pdb::query("
CREATE TABLE IF NOT EXISTS ~dummy(
    id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
    value varchar(255) NOT NULL
)", [], 'null');

try {
    Pdb::insert('dummy', ['id' => 1, 'value' => 'a\b']);
} catch (Exception) {
    // Assume record exists
}

function findRecord($conditions)
{
    $res = Pdb::find('dummy', $conditions)->all();
    echo json_encode($conditions, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ' -> ';
    echo json_encode($res, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "\n";
}

findRecord(['value' => 'a\b']); // OK
findRecord([['value', 'CONTAINS', 'a\b']]); // Fails without this fix
```