### PR TITLE
Feat/matched updates

### DIFF
--- a/src/Drivers/PdbMysql.php
+++ b/src/Drivers/PdbMysql.php
@@ -22,10 +22,14 @@ class PdbMysql extends Pdb
     /** @inheritdoc */
     protected static function afterConnect(PDO $pdo, PdbConfig $config, array $options)
     {
+        if (!isset($options[PDO::MYSQL_ATTR_FOUND_ROWS])) {
+            // This makes UPDATE predictable and behave the same as other DBMS.
+            $options[PDO::MYSQL_ATTR_FOUND_ROWS] = true;
+        }
+
         if ($config->getHack(PdbConfig::HACK_NO_ENGINE_SUBSTITUTION)) {
             $pdo->query("SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'");
         }
-
 
         // Set our TZ on the session.
         // The 'config.session' can still override this.

--- a/src/Drivers/PdbMysql.php
+++ b/src/Drivers/PdbMysql.php
@@ -20,13 +20,20 @@ class PdbMysql extends Pdb
 {
 
     /** @inheritdoc */
-    protected static function afterConnect(PDO $pdo, PdbConfig $config, array $options)
+    public static function connect($config, array $options = [])
     {
         if (!isset($options[PDO::MYSQL_ATTR_FOUND_ROWS])) {
             // This makes UPDATE predictable and behave the same as other DBMS.
             $options[PDO::MYSQL_ATTR_FOUND_ROWS] = true;
         }
 
+        return parent::connect($config, $options);
+    }
+
+
+    /** @inheritdoc */
+    protected static function afterConnect(PDO $pdo, PdbConfig $config, array $options)
+    {
         if ($config->getHack(PdbConfig::HACK_NO_ENGINE_SUBSTITUTION)) {
             $pdo->query("SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'");
         }

--- a/src/Pdb.php
+++ b/src/Pdb.php
@@ -897,7 +897,7 @@ abstract class Pdb implements Loggable, Serializable, NotSerializable, PdbDriver
      * @param string $table The table (without prefix) to insert the data into
      * @param array $data Data to update, column => value
      * @param array $conditions Conditions for updates. {@see Pdb::buildClause}
-     * @return int The number of affected rows
+     * @return int The number of matched rows
      * @throws InvalidArgumentException
      * @throws QueryException
      * @throws ConnectionException

--- a/src/PdbModelTrait.php
+++ b/src/PdbModelTrait.php
@@ -257,6 +257,7 @@ trait PdbModelTrait
      *
      * @return bool
      * @throws InvalidArgumentException
+     * @throws RowMissingException
      * @throws QueryException
      * @throws ConnectionException
      */
@@ -308,6 +309,7 @@ trait PdbModelTrait
      *
      * @param array $data as created by {@see getSaveData()}, this is mutable
      * @return void
+     * @throws RowMissingException
      */
     protected function _internalSave(array &$data)
     {
@@ -315,7 +317,11 @@ trait PdbModelTrait
         $table = static::getTableName();
 
         if (!empty($this->id)) {
-            $pdb->update($table, $data, [ 'id' => $this->id ]);
+            $count = $pdb->update($table, $data, [ 'id' => $this->id ]);
+
+            if (!$count) {
+                throw new RowMissingException("Failed to update record for '{$table}'");
+            }
         }
         else {
             $data['id'] = $pdb->insert($table, $data);

--- a/tests/BasePdbCase.php
+++ b/tests/BasePdbCase.php
@@ -193,6 +193,33 @@ abstract class BasePdbCase extends TestCase
     }
 
 
+    public function testUpdateRows()
+    {
+        $data = [
+            'date_added' => $this->pdb->now(),
+            'data' => 'test1',
+        ];
+        $id = $this->pdb->insert('logs', $data);
+
+        $data = [
+            'date_added' => $this->pdb->now(),
+            'data' => 'test2',
+        ];
+
+        // 'affected' rows returns 1.
+        $count = $this->pdb->update('logs', $data, ['id' => $id]);
+        $this->assertEquals(1, $count);
+
+        // 'affected' returns zero, but matched still returns 1.
+        $count = $this->pdb->update('logs', $data, ['id' => $id]);
+        $this->assertEquals(1, $count);
+
+        // this row doesn't exist, so returns 0 in all scenarios.
+        $count = $this->pdb->update('logs', $data, ['id' => $id + 1]);
+        $this->assertEquals(0, $count);
+    }
+
+
     public function testTimezoneNow(): void
     {
         $now = $this->pdb->now();


### PR DESCRIPTION

This PR achieves two things:
1. "Matched" is the standard behaviour for other DBMS. MySQL is the odd one out.
2. Resolves errors where we expected a model to update but it didn't. A rare scenario but undetectable otherwise.

It's unclear if we're relying on the old behaviour at all or how we would revert it for specific scenarios.

The `MYSQL_ATTR_FOUND_ROWS` const can only be set when creating the PDO object and not when when creating the prepared statement, unfortunately. So it's all or nothing.